### PR TITLE
Updated create and append actions to emit newlines

### DIFF
--- a/FileUtilities/actions.py
+++ b/FileUtilities/actions.py
@@ -9,7 +9,6 @@ from array import array
 
 logger = logging.getLogger(__name__)
 
-
 @action
 def exists_in_directory(path):
     if os.path.exists(path):
@@ -25,7 +24,8 @@ def create(filename, contents=None, overwrite=False):
     else:
         try:
             with open(filename, 'w') as new_file:
-                new_file.write(contents)
+                new_file.writelines(contents+'\n')
+		new_file.write("\n")
             return True, 'FileCreated'
         except IOError:
             print("Error writing or creating file.")
@@ -38,7 +38,7 @@ def append(filename, contents, newline=False):
         with open(filename, 'a') as f:
             if newline:
                 f.write("\n")
-            f.write(contents)
+            f.write(contents+'\n')
         return True, 'FileWritten'
     except IOError:
         print("Error writing file.")


### PR DESCRIPTION
Updated the create and append actions to emit '\n' after each line. I am a bit concerned about this fix only in that the line endings are Linux-specific, and potentially serves to break the "cross-platformedness" of WALKOFF...I am not 100% sure what the further refinement is, but this seems like a step in the right direction.