### PR TITLE
Enhances allow command by specifying an interface

### DIFF
--- a/UncomplicatedFirewall/actions.py
+++ b/UncomplicatedFirewall/actions.py
@@ -43,8 +43,12 @@ def status(verbose=False):
 
 
 @action
-def allow(port, from_address='any', to_address='any', protocol='any', comment=None):
+def allow(port, in_on=None, out-on=None, from_address='any', to_address='any', protocol='any', comment=None):
     command = ['ufw', 'allow', 'from', from_address, 'to', to_address, 'port', port, 'proto', protocol]
+    if out_on:
+        command.insert(2, ['out', 'on', out_on])
+    if in_on:
+        command.insert(2, ['in', 'on', in_on])
     if comment:
         command.extend(['comment', comment])
     return execute_command(command)

--- a/UncomplicatedFirewall/actions.py
+++ b/UncomplicatedFirewall/actions.py
@@ -44,7 +44,7 @@ def status(verbose=False):
 
 @action
 def allow(port, from_address='any', to_address='any', protocol='any', comment=None):
-    command = (['ufw', 'allow', 'from', from_address, 'to', to_address, 'port', port, 'proto', protocol])
+    command = ['ufw', 'allow', 'from', from_address, 'to', to_address, 'port', port, 'proto', protocol]
     if comment:
         command.extend(['comment', comment])
     return execute_command(command)

--- a/UncomplicatedFirewall/api.yaml
+++ b/UncomplicatedFirewall/api.yaml
@@ -75,6 +75,16 @@ actions:
         default: any
         minLength: 3
         example: '207.43.232.182'
+      - name: in_on
+        description: Interface to allow packets in on.
+        type: string
+        minLength: 2
+      - name: out_on
+        example: em1
+        description: Interface to allow packets out on.
+        type: string
+        minLength: 2
+        example: em1
       - name: to_address
         description: Address to allow connections from.
         type: string


### PR DESCRIPTION
Adds the 'in on <iface>' or 'out on <iface>' syntax when specifying an allow rule.
Note that this does not prevent specifying both in and out interfaces at the same time.  The current release of ufw may not allow this, as it implies a forwarded packet, rather than one going to or from the ufw host.